### PR TITLE
Add reminders list endpoint and simple chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,10 @@ This project is a web-based AI voice assistant application designed to provide u
 *   更完善的设置页面 (Comprehensive Settings Page)
 *   更自然的对话流程 (More natural conversation flow)
 
+### 最近进展 (Recent Progress)
+
+* 后端 `/reminders` 现在可以返回已设置的所有提醒。
+* `/chat` 路由提供了简单的规则回复，为后续接入大模型做准备。
+
 ---
 欢迎提出改进建议！(Contributions and suggestions are welcome!)

--- a/backend/app.py
+++ b/backend/app.py
@@ -76,14 +76,39 @@ def get_contacts_api():
         if conn:
             conn.close()
 
-# ... (Keep other placeholder endpoints for /chat, /reminders etc.) ...
+# ... (Basic echo chat endpoint, placeholder for future Gemini integration) ...
 @app.route('/chat', methods=['POST'])
 def chat():
-   return jsonify({"reply": "Chat endpoint not fully implemented yet. Gemini integration pending."}), 501
+    data = request.json
+    user_message = data.get('message', '').strip() if data else ''
+    if not user_message:
+        return jsonify({"error": "Message is required."}), 400
+
+    # Simple rule-based response for now
+    if '你好' in user_message or '您好' in user_message:
+        reply = '你好，很高兴与您聊天。'
+    elif '谢谢' in user_message:
+        reply = '不用客气！'
+    else:
+        reply = f"你说：{user_message}"
+
+    return jsonify({"reply": reply}), 200
 
 @app.route('/reminders', methods=['GET'])
 def get_reminders_api():
-   return jsonify({"message": "Reminders GET not implemented"}), 501
+    conn = database.get_db_connection()
+    try:
+        reminders_cursor = conn.execute(
+            "SELECT * FROM medication_reminders ORDER BY id"
+        )
+        reminders_list = [dict(row) for row in reminders_cursor.fetchall()]
+        return jsonify(reminders_list), 200
+    except sqlite3.Error as e:
+        app.logger.error(f"Database error fetching reminders: {e}")
+        return jsonify({"error": "Database operation failed."}), 500
+    finally:
+        if conn:
+            conn.close()
 
 @app.route('/reminders/due', methods=['GET'])
 def get_due_reminders_api():


### PR DESCRIPTION
## Summary
- expand progress notes in README
- implement a basic echo chat endpoint
- implement GET `/reminders` to list reminders
- add missing newline to README

## Testing
- `python -m py_compile backend/app.py backend/database.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b7b16000832290b18056b1ed38b0